### PR TITLE
other ports are now a thing if they exist in the address (in the -mpjoin argument)

### DIFF
--- a/HexcellsMpMod/MpModManager.cs
+++ b/HexcellsMpMod/MpModManager.cs
@@ -72,10 +72,10 @@ namespace HexcellsMpMod
 		private void OnDestroy()
 		{
 			Disconnect();
-			if (server != null)
-			{
+			if(server != null)
+            {
 				server.Dispose();
-			}
+            }
 			Library.Deinitialize();
 		}
 
@@ -177,17 +177,17 @@ namespace HexcellsMpMod
 		private void StartGameCustomCB(int levelIndex, string levelText)
 		{
 			var levelManager = GameObject.Find("Custom Level Manager(Clone)").GetComponent<CustomLevelManager>();
-
+			
 			levelManager.SetRandomMusic();
 			levelManager.levelDataString = levelText;
 			levelManager.currentLevelIndex = levelIndex;
 
-			GameObject.Find("Fader").GetComponent<FaderScript>().FadeOut(38);
+            GameObject.Find("Fader").GetComponent<FaderScript>().FadeOut(38);
 			if (GameObject.Find("Loading Text") != null)
 			{
 				GameObject.Find("Loading Text").GetComponent<LoadingText>().FadeIn();
 			}
-		}
+        }
 
 		public void HostStartGame(int seed, bool hardMode)
 		{
@@ -199,7 +199,7 @@ namespace HexcellsMpMod
 
 		public void HostStartGame(int levelIndex, string levelData)
 		{
-			if (server != null)
+			if(server != null)
 			{
 				server.StartCustomGame(levelIndex, levelData);
 			}
@@ -261,7 +261,7 @@ namespace HexcellsMpMod
 			boxStyle.normal.textColor = Color.white;
 			boxStyle.richText = true;
 			boxStyle.padding = new RectOffset(8, 8, 2, 2);
-
+			
 			boxStyleDone = new GUIStyle(boxStyle);
 			boxStyleDone.normal.background = Utils.MakeTex(2, 2, Color.white);
 			boxStyleDone.normal.textColor = Color.white;
@@ -402,9 +402,9 @@ namespace HexcellsMpMod
 
 			// detect mouse hovering card area and set UI color accordingly
 			Vector3 mousePosition = Input.mousePosition;
-			bool mouseHoveringUI = (mousePosition.x >= drawOriginX && mousePosition.x <= drawEndX)
-								&& (mousePosition.y > (Screen.height - drawEndY));
-
+			bool mouseHoveringUI = (mousePosition.x >= drawOriginX && mousePosition.x <= drawEndX) 
+							    && (mousePosition.y > (Screen.height - drawEndY));
+			
 			Color oldUIColor = GUI.color;
 			GUI.color = (mouseHoveringUI) ? new Color(1f, 1f, 1f, 0.5f) : Color.white;
 

--- a/HexcellsMpMod/MpModManager.cs
+++ b/HexcellsMpMod/MpModManager.cs
@@ -100,7 +100,11 @@ namespace HexcellsMpMod
 				if (address.Contains(":"))
 				{
 					string[] addressAndPort = address.Split(':');
-					client.Connect(addressAndPort[0], ushort.Parse(addressAndPort[1]));
+					if (ushort.TryParse(addressAndPort[1], out ushort port))
+					{
+						client.Connect(addressAndPort[0], port);
+					}
+
 				}
 				else
 				{

--- a/HexcellsMpMod/MpModManager.cs
+++ b/HexcellsMpMod/MpModManager.cs
@@ -72,10 +72,10 @@ namespace HexcellsMpMod
 		private void OnDestroy()
 		{
 			Disconnect();
-			if(server != null)
-            {
+			if (server != null)
+			{
 				server.Dispose();
-            }
+			}
 			Library.Deinitialize();
 		}
 
@@ -97,7 +97,15 @@ namespace HexcellsMpMod
 					OnGameStartCustom = new Action<int, string>(StartGameCustomCB),
 					OnGameEnd = new Action(QuitGameCB)
 				};
-				client.Connect(address, 6666);
+				if (address.Contains(":"))
+				{
+					string[] addressAndPort = address.Split(':');
+					client.Connect(addressAndPort[0], int.Parse(addressAndPort[1]));
+				}
+				else
+				{
+					client.Connect(address, 6666);
+				}
 			}
 			catch (Exception ex)
 			{
@@ -165,17 +173,17 @@ namespace HexcellsMpMod
 		private void StartGameCustomCB(int levelIndex, string levelText)
 		{
 			var levelManager = GameObject.Find("Custom Level Manager(Clone)").GetComponent<CustomLevelManager>();
-			
+
 			levelManager.SetRandomMusic();
 			levelManager.levelDataString = levelText;
 			levelManager.currentLevelIndex = levelIndex;
 
-            GameObject.Find("Fader").GetComponent<FaderScript>().FadeOut(38);
+			GameObject.Find("Fader").GetComponent<FaderScript>().FadeOut(38);
 			if (GameObject.Find("Loading Text") != null)
 			{
 				GameObject.Find("Loading Text").GetComponent<LoadingText>().FadeIn();
 			}
-        }
+		}
 
 		public void HostStartGame(int seed, bool hardMode)
 		{
@@ -187,7 +195,7 @@ namespace HexcellsMpMod
 
 		public void HostStartGame(int levelIndex, string levelData)
 		{
-			if(server != null)
+			if (server != null)
 			{
 				server.StartCustomGame(levelIndex, levelData);
 			}
@@ -249,7 +257,7 @@ namespace HexcellsMpMod
 			boxStyle.normal.textColor = Color.white;
 			boxStyle.richText = true;
 			boxStyle.padding = new RectOffset(8, 8, 2, 2);
-			
+
 			boxStyleDone = new GUIStyle(boxStyle);
 			boxStyleDone.normal.background = Utils.MakeTex(2, 2, Color.white);
 			boxStyleDone.normal.textColor = Color.white;
@@ -390,9 +398,9 @@ namespace HexcellsMpMod
 
 			// detect mouse hovering card area and set UI color accordingly
 			Vector3 mousePosition = Input.mousePosition;
-			bool mouseHoveringUI = (mousePosition.x >= drawOriginX && mousePosition.x <= drawEndX) 
-							    && (mousePosition.y > (Screen.height - drawEndY));
-			
+			bool mouseHoveringUI = (mousePosition.x >= drawOriginX && mousePosition.x <= drawEndX)
+								&& (mousePosition.y > (Screen.height - drawEndY));
+
 			Color oldUIColor = GUI.color;
 			GUI.color = (mouseHoveringUI) ? new Color(1f, 1f, 1f, 0.5f) : Color.white;
 

--- a/HexcellsMpMod/MpModManager.cs
+++ b/HexcellsMpMod/MpModManager.cs
@@ -100,7 +100,7 @@ namespace HexcellsMpMod
 				if (address.Contains(":"))
 				{
 					string[] addressAndPort = address.Split(':');
-					client.Connect(addressAndPort[0], int.Parse(addressAndPort[1]));
+					client.Connect(addressAndPort[0], ushort.Parse(addressAndPort[1]));
 				}
 				else
 				{

--- a/HexcellsMpMod/MpModManager.cs
+++ b/HexcellsMpMod/MpModManager.cs
@@ -104,7 +104,6 @@ namespace HexcellsMpMod
 					{
 						client.Connect(addressAndPort[0], port);
 					}
-
 				}
 				else
 				{


### PR DESCRIPTION
title. there is simply an added if statement in the code that adds this behavior by checking for a port in the address. This can be used to host a multiplayer session without needing to port forward, by using a tunnel (from playit.gg, for example).

Steps to set up multiplayer hosting using a playit.gg tunnel:
1. You'll need to make an account at https://playit.gg first. You might need to verify your e-mail, so verify it if asked to.
2. After that, get to https://playit.gg/account/agents and download the program as said in the light blue tooltip. install the program and you will have installed an agent for tunnelling. you should be able to run the agent from an icon on your desktop. I think you can run it now, so do that. It might ask you to authenticate in some way, so do that as well.
3. Go to https://playit.gg/account/tunnels and click "add tunnel". To configure this tunnel, stay in the "Use Shared IP" tab. Keep the Region at "Global Anycast". For Tunnel Type, select "TCP+UDP (Protocol)". You will likely get a message telling you not to use their service maliciously - agree with it. Leave the Port Count at 1. Set Local Port to 6666. Leave the tunnel enabled (leave the "Enable Tunnel" checkbox checked). You can now press "Add Tunnel".
4. Open (click on) the tunnel from https://playit.gg/account/tunnels, then scroll down and change your local address to 127.0.0.1 and your local port to 6666, if it is not 6666 already. After configuring these values, click "Update" to save them.
5. If the playit.gg console (agent) displays one tunnel, you are good to go to the next step. if not, restart the playit.gg agent and it should work.
6. You can give your friends the first (text) IP address (**with** the port and **with** the colon), as shown at the top of the configuration page of your newly made tunnel (i screenshotted the spot).
![image](https://github.com/user-attachments/assets/9188ed82-0e10-4068-868e-3ea6ff46405e)
